### PR TITLE
Increased frequency of apy updates

### DIFF
--- a/project-aleph-zero.yaml
+++ b/project-aleph-zero.yaml
@@ -27,8 +27,8 @@ dataSources:
         - handler: handleAlephZeroNewEra
           kind: substrate/EventHandler
           filter:
-            module: staking
-            method: StakersElected
+            module: session
+            method: NewSession
 
         - handler: handleAlephZeroStakingReward
           kind: substrate/EventHandler

--- a/project-aleph-zero.yaml
+++ b/project-aleph-zero.yaml
@@ -27,6 +27,12 @@ dataSources:
         - handler: handleAlephZeroNewEra
           kind: substrate/EventHandler
           filter:
+            module: staking
+            method: StakersElected
+
+        - handler: handleAlephZeroNewSession
+          kind: substrate/EventHandler
+          filter:
             module: session
             method: NewSession
 

--- a/project-kusama.yaml
+++ b/project-kusama.yaml
@@ -19,7 +19,7 @@ network:
   dictionary: "https://api.subquery.network/sq/subquery/kusama-dictionary"
 dataSources:
   - kind: substrate/Runtime
-    startBlock: 18579664
+    startBlock: 1
     mapping:
       file: ./dist/index.js
       handlers:

--- a/project-kusama.yaml
+++ b/project-kusama.yaml
@@ -19,15 +19,15 @@ network:
   dictionary: "https://api.subquery.network/sq/subquery/kusama-dictionary"
 dataSources:
   - kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 18579664
     mapping:
       file: ./dist/index.js
       handlers:
         - handler: handleKusamaNewEra
           kind: substrate/EventHandler
           filter:
-            module: staking
-            method: StakersElected
+            module: session
+            method: NewSession
 
         - handler: handleKusamaStakingReward
           kind: substrate/EventHandler

--- a/project-kusama.yaml
+++ b/project-kusama.yaml
@@ -26,6 +26,12 @@ dataSources:
         - handler: handleKusamaNewEra
           kind: substrate/EventHandler
           filter:
+            module: staking
+            method: StakersElected
+
+        - handler: handleKusamaNewSession
+          kind: substrate/EventHandler
+          filter:
             module: session
             method: NewSession
 

--- a/project-polkadex.yaml
+++ b/project-polkadex.yaml
@@ -28,6 +28,12 @@ dataSources:
         - handler: handlePolkadexNewEra
           kind: substrate/EventHandler
           filter:
+            module: staking
+            method: StakersElected
+
+        - handler: handlePolkadexNewSession
+          kind: substrate/EventHandler
+          filter:
             module: session
             method: NewSession
 

--- a/project-polkadex.yaml
+++ b/project-polkadex.yaml
@@ -28,8 +28,8 @@ dataSources:
         - handler: handlePolkadexNewEra
           kind: substrate/EventHandler
           filter:
-            module: staking
-            method: StakersElected
+            module: session
+            method: NewSession
 
         - handler: handlePolkadexStakingReward
           kind: substrate/EventHandler

--- a/project-polkadot.yaml
+++ b/project-polkadot.yaml
@@ -26,6 +26,12 @@ dataSources:
         - handler: handlePolkadotNewEra
           kind: substrate/EventHandler
           filter:
+            module: staking
+            method: StakersElected
+
+        - handler: handlePolkadotNewSession
+          kind: substrate/EventHandler
+          filter:
             module: session
             method: NewSession
 

--- a/project-polkadot.yaml
+++ b/project-polkadot.yaml
@@ -26,8 +26,8 @@ dataSources:
         - handler: handlePolkadotNewEra
           kind: substrate/EventHandler
           filter:
-            module: staking
-            method: StakersElected
+            module: session
+            method: NewSession
 
         - handler: handlePolkadotStakingReward
           kind: substrate/EventHandler

--- a/project-ternoa.yaml
+++ b/project-ternoa.yaml
@@ -27,6 +27,12 @@ dataSources:
         - handler: handleTernoaNewEra
           kind: substrate/EventHandler
           filter:
+            module: staking
+            method: StakersElected
+
+        - handler: handleTernoaNewSession
+          kind: substrate/EventHandler
+          filter:
             module: session
             method: NewSession
 

--- a/project-ternoa.yaml
+++ b/project-ternoa.yaml
@@ -27,8 +27,8 @@ dataSources:
         - handler: handleTernoaNewEra
           kind: substrate/EventHandler
           filter:
-            module: staking
-            method: StakersElected
+            module: session
+            method: NewSession
 
         - handler: handleTernoaStakingReward
           kind: substrate/EventHandler

--- a/project-westend.yaml
+++ b/project-westend.yaml
@@ -30,6 +30,12 @@ dataSources:
             module: staking
             method: StakersElected
 
+        - handler: handleWestendNewSession
+          kind: substrate/EventHandler
+          filter:
+            module: session
+            method: NewSession
+
         - handler: handleWestendStakingReward
           kind: substrate/EventHandler
           filter:

--- a/src/mappings/aleph-zero.ts
+++ b/src/mappings/aleph-zero.ts
@@ -1,5 +1,5 @@
 import {SubstrateEvent} from "@subql/types";
-import {handleNewEra} from "./common";
+import {handleNewEra, handleNewSession} from "./common";
 import {AlephZeroRewardCalculator} from "./rewards/AlephZero";
 import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
 import {Codec} from "@polkadot/types/types";
@@ -13,6 +13,17 @@ export async function handleAlephZeroNewEra(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
 
     await handleNewEra(
+        validatorEraInfoDataSource,
+        new AlephZeroRewardCalculator(validatorEraInfoDataSource),
+        ALEPH_ZERO_GENESIS,
+        STAKING_TYPE
+    )
+}
+
+export async function handleAlephZeroNewSession(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+
+    await handleNewSession(
         validatorEraInfoDataSource,
         new AlephZeroRewardCalculator(validatorEraInfoDataSource),
         ALEPH_ZERO_GENESIS,

--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -17,7 +17,7 @@ export async function handleNewEra(
 
     await stakingStats.indexEra()
 
-    if(stakingType != 'relaychain' && stakingType != 'aleph-zero') {
+    if(stakingType !== 'relaychain' && stakingType !== 'aleph-zero') {
         await stakingStats.indexSession()
     }
 }

--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -1,5 +1,4 @@
 import {RewardCalculator} from "./rewards/RewardCalculator";
-import {StakingApy} from "../types";
 import {EraInfoDataSource} from "./era/EraInfoDataSource";
 import {StakingStats} from "./stats/StakingStats";
 
@@ -16,5 +15,25 @@ export async function handleNewEra(
         stakingType
     )
 
-    await stakingStats.indexEraStats()
+    await stakingStats.indexEra()
+
+    if(stakingType != 'relaychain' && stakingType != 'aleph-zero') {
+        await stakingStats.indexSession()
+    }
+}
+
+export async function handleNewSession(
+    eraInfoDataSource: EraInfoDataSource,
+    rewardCalculator: RewardCalculator,
+    networkId: string,
+    stakingType: string
+): Promise<void> {
+    const stakingStats = new StakingStats(
+        rewardCalculator,
+        eraInfoDataSource,
+        networkId,
+        stakingType
+    )
+
+    await stakingStats.indexSession()
 }

--- a/src/mappings/common.ts
+++ b/src/mappings/common.ts
@@ -16,10 +16,6 @@ export async function handleNewEra(
     )
 
     await stakingStats.indexEra()
-
-    if(stakingType !== 'relaychain' && stakingType !== 'aleph-zero') {
-        await stakingStats.indexSession()
-    }
 }
 
 export async function handleNewSession(

--- a/src/mappings/era/CachingEraInfoDataSource.ts
+++ b/src/mappings/era/CachingEraInfoDataSource.ts
@@ -22,6 +22,8 @@ export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
         return this._eraStakers
     }
 
+    abstract eraStarted(): Promise<boolean>
+
     protected abstract fetchEraStakers(): Promise<StakeTarget[]>
 
     protected abstract fetchEra(): Promise<number>

--- a/src/mappings/era/CachingEraInfoDataSource.ts
+++ b/src/mappings/era/CachingEraInfoDataSource.ts
@@ -1,10 +1,10 @@
 import {EraInfoDataSource, StakeTarget} from "./EraInfoDataSource";
 
+let cachedStakers: StakeTarget[] | undefined = undefined
+
 export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
 
     private _era: number
-
-    private _eraStakers: StakeTarget[]
 
     async era(): Promise<number> {
         if (this._era == undefined) {
@@ -14,12 +14,21 @@ export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
         return this._era
     }
 
-    async eraStakers(): Promise<StakeTarget[]> {
-        if (this._eraStakers == undefined) {
-            this._eraStakers = await this.fetchEraStakers()
+    async eraStakers(cached: boolean): Promise<StakeTarget[]> {
+        if (cached) {
+            if (cachedStakers === undefined) {
+                return await this.updateCachedStakers();
+            } else {
+                return cachedStakers
+            }
+        } else {
+            return await this.updateCachedStakers()
         }
+    }
 
-        return this._eraStakers
+    private async updateCachedStakers(): Promise<StakeTarget[]> {
+        cachedStakers = await this.fetchEraStakers()
+        return cachedStakers
     }
 
     abstract eraStarted(): Promise<boolean>

--- a/src/mappings/era/CachingEraInfoDataSource.ts
+++ b/src/mappings/era/CachingEraInfoDataSource.ts
@@ -32,21 +32,16 @@ export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
         return cachedStakers
     }
 
-    async eraComissions(forceRefresh: boolean): Promise<Record<string, number>> {
-        if (!forceRefresh) {
-            if (cachedComissions === undefined) {
-                return await this.updateComissions();
-            } else {
-                return cachedComissions
-            }
-        } else {
-            return await this.updateComissions()
-        }
+    async cachedEraComissions(): Promise<Record<string, number>> {
+        if (cachedComissions === undefined) {
+            await this.updateEraComissions();
+        } 
+
+        return cachedComissions
     }
 
-    private async updateComissions(): Promise<Record<string, number>> {
+    async updateEraComissions(): Promise<void> {
         cachedComissions = await this.fetchComissions();
-        return cachedComissions
     }
 
     abstract eraStarted(): Promise<boolean>

--- a/src/mappings/era/CachingEraInfoDataSource.ts
+++ b/src/mappings/era/CachingEraInfoDataSource.ts
@@ -1,10 +1,11 @@
 import {EraInfoDataSource, StakeTarget} from "./EraInfoDataSource";
 
 let cachedStakers: StakeTarget[] | undefined = undefined
+let cachedComissions: Record<string, number> | undefined = undefined
 
 export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
 
-    private _era: number
+    protected _era: number
 
     async era(): Promise<number> {
         if (this._era == undefined) {
@@ -14,8 +15,8 @@ export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
         return this._era
     }
 
-    async eraStakers(cached: boolean): Promise<StakeTarget[]> {
-        if (cached) {
+    async eraStakers(forceRefresh: boolean): Promise<StakeTarget[]> {
+        if (!forceRefresh) {
             if (cachedStakers === undefined) {
                 return await this.updateCachedStakers();
             } else {
@@ -31,9 +32,28 @@ export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
         return cachedStakers
     }
 
+    async eraComissions(forceRefresh: boolean): Promise<Record<string, number>> {
+        if (!forceRefresh) {
+            if (cachedComissions === undefined) {
+                return await this.updateComissions();
+            } else {
+                return cachedComissions
+            }
+        } else {
+            return await this.updateComissions()
+        }
+    }
+
+    private async updateComissions(): Promise<Record<string, number>> {
+        cachedComissions = await this.fetchComissions();
+        return cachedComissions
+    }
+
     abstract eraStarted(): Promise<boolean>
 
     protected abstract fetchEraStakers(): Promise<StakeTarget[]>
+
+    protected abstract fetchComissions(): Promise<Record<string, number>>
 
     protected abstract fetchEra(): Promise<number>
 }

--- a/src/mappings/era/CollatorEraInfoDataSource.ts
+++ b/src/mappings/era/CollatorEraInfoDataSource.ts
@@ -7,6 +7,10 @@ import {Struct, Vec} from "@polkadot/types-codec";
 
 export class CollatorEraInfoDataSource extends CachingEraInfoDataSource {
 
+    async eraStarted(): Promise<boolean> {
+        return true
+    }
+
     protected async fetchEra(): Promise<number> {
         const round = (await api.query.parachainStaking.round())
         return round.current.toNumber()

--- a/src/mappings/era/CollatorEraInfoDataSource.ts
+++ b/src/mappings/era/CollatorEraInfoDataSource.ts
@@ -1,9 +1,9 @@
 import {StakeTarget} from "./EraInfoDataSource";
 import {CachingEraInfoDataSource} from "./CachingEraInfoDataSource";
-import {BigFromINumber} from "../utils";
+import {BigFromINumber, PerbillToNumber} from "../utils";
 import '@moonbeam-network/api-augment'
 import {PalletParachainStakingBond, PalletParachainStakingCollatorSnapshot} from "@polkadot/types/lookup";
-import {Struct, Vec} from "@polkadot/types-codec";
+import {Vec} from "@polkadot/types-codec";
 
 export class CollatorEraInfoDataSource extends CachingEraInfoDataSource {
 
@@ -14,6 +14,11 @@ export class CollatorEraInfoDataSource extends CachingEraInfoDataSource {
     protected async fetchEra(): Promise<number> {
         const round = (await api.query.parachainStaking.round())
         return round.current.toNumber()
+    }
+
+    protected async fetchComissions(): Promise<Record<string, number>> {
+        const commission = PerbillToNumber(await api.query.parachainStaking.collatorCommission())
+        return {"collator": commission}
     }
 
     protected async fetchEraStakers(): Promise<StakeTarget[]> {

--- a/src/mappings/era/EraInfoDataSource.ts
+++ b/src/mappings/era/EraInfoDataSource.ts
@@ -5,6 +5,8 @@ export interface EraInfoDataSource {
     era(): Promise<number>
 
     eraStakers(): Promise<StakeTarget[]>
+
+    eraStarted(): Promise<boolean>
 }
 
 export interface StakeTarget {

--- a/src/mappings/era/EraInfoDataSource.ts
+++ b/src/mappings/era/EraInfoDataSource.ts
@@ -6,7 +6,9 @@ export interface EraInfoDataSource {
 
     eraStakers(forceRefresh: boolean): Promise<StakeTarget[]>
 
-    eraComissions(forceRefresh: boolean): Promise<Record<string, number>>
+    cachedEraComissions(): Promise<Record<string, number>>
+
+    updateEraComissions(): Promise<void>
 
     eraStarted(): Promise<boolean>
 }

--- a/src/mappings/era/EraInfoDataSource.ts
+++ b/src/mappings/era/EraInfoDataSource.ts
@@ -4,7 +4,7 @@ export interface EraInfoDataSource {
 
     era(): Promise<number>
 
-    eraStakers(): Promise<StakeTarget[]>
+    eraStakers(cached: boolean): Promise<StakeTarget[]>
 
     eraStarted(): Promise<boolean>
 }

--- a/src/mappings/era/EraInfoDataSource.ts
+++ b/src/mappings/era/EraInfoDataSource.ts
@@ -4,9 +4,22 @@ export interface EraInfoDataSource {
 
     era(): Promise<number>
 
-    eraStakers(cached: boolean): Promise<StakeTarget[]>
+    eraStakers(forceRefresh: boolean): Promise<StakeTarget[]>
+
+    eraComissions(forceRefresh: boolean): Promise<Record<string, number>>
 
     eraStarted(): Promise<boolean>
+}
+
+export interface StakeTarget {
+
+    address: string
+
+    selfStake: bigint
+
+    totalStake: Big
+
+    others: Staker[]
 }
 
 export interface StakeTarget {

--- a/src/mappings/era/ValidatorEraInfoDataSource.ts
+++ b/src/mappings/era/ValidatorEraInfoDataSource.ts
@@ -7,11 +7,11 @@ import {PalletStakingExposure} from "@polkadot/types/lookup";
 export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
 
     async eraStarted(): Promise<boolean> {
-        if (api.query['staking'] === undefined || (typeof api.query.staking['currentEra']) === 'function') {
+        if (api.query['staking'] === undefined || (typeof api.query.staking['currentEra']) !== 'function') {
             return false
         }
         const era = (await api.query.staking.currentEra())
-        return era.isSome
+        return era.isSome && era.unwrap().toNumber() > 0
     }
 
     protected async fetchEra(): Promise<number> {

--- a/src/mappings/era/ValidatorEraInfoDataSource.ts
+++ b/src/mappings/era/ValidatorEraInfoDataSource.ts
@@ -6,6 +6,14 @@ import {PalletStakingExposure} from "@polkadot/types/lookup";
 
 export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
 
+    async eraStarted(): Promise<boolean> {
+        if (api.query['staking'] === undefined || (typeof api.query.staking['currentEra']) === 'function') {
+            return false
+        }
+        const era = (await api.query.staking.currentEra())
+        return era.isSome
+    }
+
     protected async fetchEra(): Promise<number> {
         return (await api.query.staking.currentEra()).unwrap().toNumber()
     }

--- a/src/mappings/kusama.ts
+++ b/src/mappings/kusama.ts
@@ -1,5 +1,5 @@
 import {SubstrateEvent} from "@subql/types";
-import {handleNewEra} from "./common";
+import {handleNewEra, handleNewSession} from "./common";
 import {RelaychainRewardCalculator} from "./rewards/Relaychain";
 import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
 import {Codec} from "@polkadot/types/types";
@@ -13,6 +13,17 @@ export async function handleKusamaNewEra(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
 
     await handleNewEra(
+        validatorEraInfoDataSource,
+        await RelaychainRewardCalculator(validatorEraInfoDataSource),
+        KUSAMA_GENESIS,
+        STAKING_TYPE
+    )
+}
+
+export async function handleKusamaNewSession(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+
+    await handleNewSession(
         validatorEraInfoDataSource,
         await RelaychainRewardCalculator(validatorEraInfoDataSource),
         KUSAMA_GENESIS,

--- a/src/mappings/polkadex.ts
+++ b/src/mappings/polkadex.ts
@@ -1,5 +1,5 @@
 import {SubstrateEvent} from "@subql/types";
-import {handleNewEra} from "./common";
+import {handleNewEra, handleNewSession} from "./common";
 import {RelaychainRewardCalculator} from "./rewards/Relaychain";
 import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
 import {Codec} from "@polkadot/types/types";
@@ -13,6 +13,17 @@ export async function handlePolkadexNewEra(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
 
     await handleNewEra(
+        validatorEraInfoDataSource,
+        await RelaychainRewardCalculator(validatorEraInfoDataSource),
+        POLKADEX_GENESIS,
+        STAKING_TYPE
+    )
+}
+
+export async function handlePolkadexNewSession(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+
+    await handleNewSession(
         validatorEraInfoDataSource,
         await RelaychainRewardCalculator(validatorEraInfoDataSource),
         POLKADEX_GENESIS,

--- a/src/mappings/polkadot.ts
+++ b/src/mappings/polkadot.ts
@@ -1,5 +1,5 @@
 import {SubstrateEvent} from "@subql/types";
-import {handleNewEra} from "./common";
+import {handleNewEra, handleNewSession} from "./common";
 import {RelaychainRewardCalculator} from "./rewards/Relaychain";
 import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
 import {Codec} from "@polkadot/types/types";
@@ -13,6 +13,17 @@ export async function handlePolkadotNewEra(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
 
     await handleNewEra(
+        validatorEraInfoDataSource,
+        await RelaychainRewardCalculator(validatorEraInfoDataSource),
+        POLKADOT_GENESIS,
+        STAKING_TYPE
+    )
+}
+
+export async function handlePolkadotNewSession(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+
+    await handleNewSession(
         validatorEraInfoDataSource,
         await RelaychainRewardCalculator(validatorEraInfoDataSource),
         POLKADOT_GENESIS,

--- a/src/mappings/rewards/CollatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/CollatorStakingRewardCalculator.ts
@@ -20,7 +20,7 @@ export class CollatorStakingRewardCalculator implements RewardCalculator {
 		let totalIssuance = await this.fetchTotalIssuance()
 		let round = await this.eraInfoDataSource.era()
 		let totalStaked = await this.fetchTotalStaked(round)
-		let collators = await this.eraInfoDataSource.eraStakers(true)
+		let collators = await this.eraInfoDataSource.eraStakers(false)
 		let collatorCommission = await this.fetchCommission()
 		let parachainBondPercent = await this.fetchParachainBondPercent()
 
@@ -83,7 +83,7 @@ export class CollatorStakingRewardCalculator implements RewardCalculator {
     }
 
     private async fetchCommission(): Promise<number> {
-    	const collatorCommission = await api.query.parachainStaking.collatorCommission()
-    	return PerbillToNumber(collatorCommission)
+    	const collatorCommission = await this.eraInfoDataSource.eraComissions(false)
+    	return collatorCommission["collator"]
     }
 }

--- a/src/mappings/rewards/CollatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/CollatorStakingRewardCalculator.ts
@@ -20,7 +20,7 @@ export class CollatorStakingRewardCalculator implements RewardCalculator {
 		let totalIssuance = await this.fetchTotalIssuance()
 		let round = await this.eraInfoDataSource.era()
 		let totalStaked = await this.fetchTotalStaked(round)
-		let collators = await this.eraInfoDataSource.eraStakers()
+		let collators = await this.eraInfoDataSource.eraStakers(true)
 		let collatorCommission = await this.fetchCommission()
 		let parachainBondPercent = await this.fetchParachainBondPercent()
 

--- a/src/mappings/rewards/CollatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/CollatorStakingRewardCalculator.ts
@@ -83,7 +83,7 @@ export class CollatorStakingRewardCalculator implements RewardCalculator {
     }
 
     private async fetchCommission(): Promise<number> {
-    	const collatorCommission = await this.eraInfoDataSource.eraComissions(false)
+    	const collatorCommission = await this.eraInfoDataSource.cachedEraComissions()
     	return collatorCommission["collator"]
     }
 }

--- a/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
@@ -1,7 +1,7 @@
 import {RewardCalculator, StakerNode} from "./RewardCalculator";
 import {StakedInfo} from "./inflation/Inflation";
 import Big from "big.js";
-import {associate, BigFromINumber, PerbillToNumber} from "../utils";
+import {BigFromINumber} from "../utils";
 import {EraInfoDataSource} from "../era/EraInfoDataSource";
 
 export abstract class ValidatorStakingRewardCalculator implements RewardCalculator {
@@ -43,20 +43,14 @@ export abstract class ValidatorStakingRewardCalculator implements RewardCalculat
 
     private async fetchStakers(): Promise<StakerNode[]> {
         const currentEra = await this.eraInfoDataSource.era()
-        const eraStakers = await this.eraInfoDataSource.eraStakers(true)
+        const eraStakers = await this.eraInfoDataSource.eraStakers(false)
 
-        const commissions = await api.query.staking.erasValidatorPrefs.entries(currentEra)
-
-        const commissionByValidatorId = associate(
-            commissions,
-            ([storageKey]) => storageKey.args[1].toString(),
-            ([, prefs]) => prefs.commission,
-        )
+        const commissionByValidatorId = await this.eraInfoDataSource.eraComissions(false)
 
         return eraStakers.map(({address, totalStake}) => {
             return {
                 totalStake: totalStake,
-                commission: PerbillToNumber(commissionByValidatorId[address])
+                commission: commissionByValidatorId[address]
             }
         })
     }

--- a/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
@@ -43,7 +43,7 @@ export abstract class ValidatorStakingRewardCalculator implements RewardCalculat
 
     private async fetchStakers(): Promise<StakerNode[]> {
         const currentEra = await this.eraInfoDataSource.era()
-        const eraStakers = await this.eraInfoDataSource.eraStakers()
+        const eraStakers = await this.eraInfoDataSource.eraStakers(true)
 
         const commissions = await api.query.staking.erasValidatorPrefs.entries(currentEra)
 

--- a/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
@@ -45,7 +45,7 @@ export abstract class ValidatorStakingRewardCalculator implements RewardCalculat
         const currentEra = await this.eraInfoDataSource.era()
         const eraStakers = await this.eraInfoDataSource.eraStakers(false)
 
-        const commissionByValidatorId = await this.eraInfoDataSource.eraComissions(false)
+        const commissionByValidatorId = await this.eraInfoDataSource.cachedEraComissions()
 
         return eraStakers.map(({address, totalStake}) => {
             return {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -26,6 +26,7 @@ export class StakingStats {
 
     async indexEra(): Promise<void> {
         await this.updateActiveStakers()
+        await this.updateAPY()
     }
 
     async indexSession(): Promise<void> {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -24,9 +24,12 @@ export class StakingStats {
         this.stakingType = stakingType
     }
 
-    async indexEraStats(): Promise<void> {
-        await this.updateAPY()
+    async indexEra(): Promise<void> {
         await this.updateActiveStakers()
+    }
+
+    async indexSession(): Promise<void> {
+        await this.updateAPY()
     }
 
     private async updateAPY(): Promise<void> {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -33,16 +33,18 @@ export class StakingStats {
     }
 
     private async updateAPY(): Promise<void> {
-        let apy = await this.rewardCalculator.maxApy()
+        if (await this.eraInfoDataSource.eraStarted()) {
+            let apy = await this.rewardCalculator.maxApy()
 
-        let apyEntity = StakingApy.create({
-            id: this.generateMaxApyId(),
-            networkId: this.networkId,
-            stakingType: this.stakingType,
-            maxAPY: apy
-        })
+            let apyEntity = StakingApy.create({
+                id: this.generateMaxApyId(),
+                networkId: this.networkId,
+                stakingType: this.stakingType,
+                maxAPY: apy
+            })
 
-        await apyEntity.save()
+            await apyEntity.save()
+        }
     }
 
     private async updateActiveStakers(): Promise<void> {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -51,7 +51,8 @@ export class StakingStats {
     private async updateActiveStakers(): Promise<void> {
         await this.removeOldRecords();
 
-        let stakeTargets = await this.eraInfoDataSource.eraStakers(false)
+        let stakeTargets = await this.eraInfoDataSource.eraStakers(true)
+        await this.eraInfoDataSource.eraComissions(true) // updating comissions for APY
 
         const activeStakers: ActiveStaker[] = stakeTargets.flatMap((stakeTarget => {
             const nominators = stakeTarget.others.map((nominator) => {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -26,6 +26,7 @@ export class StakingStats {
 
     async indexEra(): Promise<void> {
         await this.updateActiveStakers()
+        await this.eraInfoDataSource.updateEraComissions()
         await this.updateAPY()
     }
 
@@ -52,7 +53,6 @@ export class StakingStats {
         await this.removeOldRecords();
 
         let stakeTargets = await this.eraInfoDataSource.eraStakers(true)
-        await this.eraInfoDataSource.updateEraComissions()
 
         const activeStakers: ActiveStaker[] = stakeTargets.flatMap((stakeTarget => {
             const nominators = stakeTarget.others.map((nominator) => {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -51,7 +51,7 @@ export class StakingStats {
     private async updateActiveStakers(): Promise<void> {
         await this.removeOldRecords();
 
-        let stakeTargets = await this.eraInfoDataSource.eraStakers()
+        let stakeTargets = await this.eraInfoDataSource.eraStakers(false)
 
         const activeStakers: ActiveStaker[] = stakeTargets.flatMap((stakeTarget => {
             const nominators = stakeTarget.others.map((nominator) => {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -52,7 +52,7 @@ export class StakingStats {
         await this.removeOldRecords();
 
         let stakeTargets = await this.eraInfoDataSource.eraStakers(true)
-        await this.eraInfoDataSource.eraComissions(true) // updating comissions for APY
+        await this.eraInfoDataSource.updateEraComissions()
 
         const activeStakers: ActiveStaker[] = stakeTargets.flatMap((stakeTarget => {
             const nominators = stakeTarget.others.map((nominator) => {

--- a/src/mappings/ternoa.ts
+++ b/src/mappings/ternoa.ts
@@ -1,5 +1,5 @@
 import {SubstrateEvent} from "@subql/types";
-import {handleNewEra} from "./common";
+import {handleNewEra, handleNewSession} from "./common";
 import {RelaychainRewardCalculator} from "./rewards/Relaychain";
 import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
 import {Codec} from "@polkadot/types/types";
@@ -13,6 +13,17 @@ export async function handleTernoaNewEra(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
 
     await handleNewEra(
+        validatorEraInfoDataSource,
+        await RelaychainRewardCalculator(validatorEraInfoDataSource),
+        TERNOA_GENESIS,
+        STAKING_TYPE
+    )
+}
+
+export async function handleTernoaNewSession(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+
+    await handleNewSession(
         validatorEraInfoDataSource,
         await RelaychainRewardCalculator(validatorEraInfoDataSource),
         TERNOA_GENESIS,

--- a/src/mappings/westend.ts
+++ b/src/mappings/westend.ts
@@ -1,5 +1,5 @@
 import {SubstrateEvent} from "@subql/types";
-import {handleNewEra} from "./common";
+import {handleNewEra, handleNewSession} from "./common";
 import {RelaychainRewardCalculator} from "./rewards/Relaychain";
 import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
 import {Codec} from "@polkadot/types/types";
@@ -13,6 +13,17 @@ export async function handleWestendNewEra(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
 
     await handleNewEra(
+        validatorEraInfoDataSource,
+        await RelaychainRewardCalculator(validatorEraInfoDataSource),
+        WESTEND_GENESIS,
+        STAKING_TYPE
+    )
+}
+
+export async function handleWestendNewSession(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+
+    await handleNewSession(
         validatorEraInfoDataSource,
         await RelaychainRewardCalculator(validatorEraInfoDataSource),
         WESTEND_GENESIS,


### PR DESCRIPTION
Separated new era handlers on apy updating in newSession and active stackers updating in newEra for relaychain and azero

Checked from 18630602 on kusama to observe two apy updates:

First:
![Screenshot from 2023-07-03 23-24-13](https://github.com/novasamatech/subquery-staking/assets/33938211/59b42b22-e126-4114-b7ea-6a00582d4379)

Second:
![Screenshot from 2023-07-03 23-24-20](https://github.com/novasamatech/subquery-staking/assets/33938211/a4546e7d-88e1-4298-b600-1aea212540c7)


Logs:
[kusama_from_18630602.log](https://github.com/novasamatech/subquery-staking/files/11941217/kusama_from_18630602.log)


Also tested on multichain to avoid errors(and there was a lot! while first era is not started I got different behaviors from different relay chains):

Graphql:
![Screenshot from 2023-07-03 23-21-28](https://github.com/novasamatech/subquery-staking/assets/33938211/1de60753-d493-4bd5-aaae-6ff84553632a)

Logs:
[all_from_1.log](https://github.com/novasamatech/subquery-staking/files/11941229/all_from_1.log)
