### PR TITLE
reverted logic with caches

### DIFF
--- a/src/mappings/era/CachingEraInfoDataSource.ts
+++ b/src/mappings/era/CachingEraInfoDataSource.ts
@@ -1,11 +1,10 @@
 import {EraInfoDataSource, StakeTarget} from "./EraInfoDataSource";
 
-let cachedStakers: StakeTarget[] | undefined = undefined
-let cachedComissions: Record<string, number> | undefined = undefined
-
 export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
 
     protected _era: number
+
+    private _eraStakers: StakeTarget[]
 
     async era(): Promise<number> {
         if (this._era == undefined) {
@@ -15,40 +14,17 @@ export abstract class CachingEraInfoDataSource implements EraInfoDataSource {
         return this._era
     }
 
-    async eraStakers(forceRefresh: boolean): Promise<StakeTarget[]> {
-        if (!forceRefresh) {
-            if (cachedStakers === undefined) {
-                return await this.updateCachedStakers();
-            } else {
-                return cachedStakers
-            }
-        } else {
-            return await this.updateCachedStakers()
+    async eraStakers(): Promise<StakeTarget[]> {
+        if (this._eraStakers == undefined) {
+            this._eraStakers = await this.fetchEraStakers()
         }
-    }
 
-    private async updateCachedStakers(): Promise<StakeTarget[]> {
-        cachedStakers = await this.fetchEraStakers()
-        return cachedStakers
-    }
-
-    async cachedEraComissions(): Promise<Record<string, number>> {
-        if (cachedComissions === undefined) {
-            await this.updateEraComissions();
-        } 
-
-        return cachedComissions
-    }
-
-    async updateEraComissions(): Promise<void> {
-        cachedComissions = await this.fetchComissions();
+        return this._eraStakers
     }
 
     abstract eraStarted(): Promise<boolean>
 
     protected abstract fetchEraStakers(): Promise<StakeTarget[]>
-
-    protected abstract fetchComissions(): Promise<Record<string, number>>
 
     protected abstract fetchEra(): Promise<number>
 }

--- a/src/mappings/era/CollatorEraInfoDataSource.ts
+++ b/src/mappings/era/CollatorEraInfoDataSource.ts
@@ -16,11 +16,6 @@ export class CollatorEraInfoDataSource extends CachingEraInfoDataSource {
         return round.current.toNumber()
     }
 
-    protected async fetchComissions(): Promise<Record<string, number>> {
-        const commission = PerbillToNumber(await api.query.parachainStaking.collatorCommission())
-        return {"collator": commission}
-    }
-
     protected async fetchEraStakers(): Promise<StakeTarget[]> {
         const round = await this.era()
         const stakes = await api.query.parachainStaking.atStake.entries(round) ?? []

--- a/src/mappings/era/EraInfoDataSource.ts
+++ b/src/mappings/era/EraInfoDataSource.ts
@@ -4,11 +4,7 @@ export interface EraInfoDataSource {
 
     era(): Promise<number>
 
-    eraStakers(forceRefresh: boolean): Promise<StakeTarget[]>
-
-    cachedEraComissions(): Promise<Record<string, number>>
-
-    updateEraComissions(): Promise<void>
+    eraStakers(): Promise<StakeTarget[]>
 
     eraStarted(): Promise<boolean>
 }

--- a/src/mappings/era/ValidatorEraInfoDataSource.ts
+++ b/src/mappings/era/ValidatorEraInfoDataSource.ts
@@ -2,7 +2,6 @@ import {StakeTarget} from "./EraInfoDataSource";
 import {CachingEraInfoDataSource} from "./CachingEraInfoDataSource";
 import {BigFromINumber} from "../utils";
 import {PalletStakingExposure} from "@polkadot/types/lookup";
-import {associate, PerbillToNumber} from "../utils";
 
 
 export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
@@ -17,17 +16,6 @@ export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
 
     protected async fetchEra(): Promise<number> {
         return (await api.query.staking.currentEra()).unwrap().toNumber()
-    }
-
-    protected async fetchComissions(): Promise<Record<string, number>> {
-        const commissions = await api.query.staking.erasValidatorPrefs.entries(await this.era())
-
-        const commissionByValidatorId = associate(
-            commissions,
-            ([storageKey]) => storageKey.args[1].toString(),
-            ([, prefs]) => PerbillToNumber(prefs.commission),
-        )
-        return commissionByValidatorId
     }
 
     protected async fetchEraStakers(): Promise<StakeTarget[]> {

--- a/src/mappings/rewards/CollatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/CollatorStakingRewardCalculator.ts
@@ -20,7 +20,7 @@ export class CollatorStakingRewardCalculator implements RewardCalculator {
 		let totalIssuance = await this.fetchTotalIssuance()
 		let round = await this.eraInfoDataSource.era()
 		let totalStaked = await this.fetchTotalStaked(round)
-		let collators = await this.eraInfoDataSource.eraStakers(false)
+		let collators = await this.eraInfoDataSource.eraStakers()
 		let collatorCommission = await this.fetchCommission()
 		let parachainBondPercent = await this.fetchParachainBondPercent()
 
@@ -83,7 +83,7 @@ export class CollatorStakingRewardCalculator implements RewardCalculator {
     }
 
     private async fetchCommission(): Promise<number> {
-    	const collatorCommission = await this.eraInfoDataSource.cachedEraComissions()
-    	return collatorCommission["collator"]
+    	const collatorCommission = await api.query.parachainStaking.collatorCommission()
+    	return PerbillToNumber(collatorCommission)
     }
 }

--- a/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
@@ -43,9 +43,9 @@ export abstract class ValidatorStakingRewardCalculator implements RewardCalculat
 
     private async fetchStakers(): Promise<StakerNode[]> {
         const currentEra = await this.eraInfoDataSource.era()
-        const eraStakers = await this.eraInfoDataSource.eraStakers(false)
+        const eraStakers = await this.eraInfoDataSource.eraStakers()
 
-        const commissionByValidatorId = await this.eraInfoDataSource.cachedEraComissions()
+        const commissionByValidatorId = await api.query.staking.erasValidatorPrefs.entries(currentEra)
 
         return eraStakers.map(({address, totalStake}) => {
             return {

--- a/src/mappings/stats/StakingStats.ts
+++ b/src/mappings/stats/StakingStats.ts
@@ -26,7 +26,6 @@ export class StakingStats {
 
     async indexEra(): Promise<void> {
         await this.updateActiveStakers()
-        await this.eraInfoDataSource.updateEraComissions()
         await this.updateAPY()
     }
 
@@ -52,7 +51,7 @@ export class StakingStats {
     private async updateActiveStakers(): Promise<void> {
         await this.removeOldRecords();
 
-        let stakeTargets = await this.eraInfoDataSource.eraStakers(true)
+        let stakeTargets = await this.eraInfoDataSource.eraStakers()
 
         const activeStakers: ActiveStaker[] = stakeTargets.flatMap((stakeTarget => {
             const nominators = stakeTarget.others.map((nominator) => {


### PR DESCRIPTION
reverted logic with caches to 060a68b964b5da39971d4a4bbdd399bc4ce0990e

Tested on 55287000 azero

![Screenshot from 2023-08-15 12-24-41](https://github.com/novasamatech/subquery-staking/assets/33938211/68f98eab-e853-4f4d-8621-5c577110dfbd)

![Screenshot from 2023-08-15 12-25-29](https://github.com/novasamatech/subquery-staking/assets/33938211/f77259e5-b34c-41af-9663-bd877b60ce38)

![Screenshot from 2023-08-15 12-26-04](https://github.com/novasamatech/subquery-staking/assets/33938211/7b3d4eac-8b80-45ea-846d-8ccde30cdc9a)

[test.log](https://github.com/novasamatech/subquery-staking/files/12343258/test.log)
