### PR TITLE
Ensure Mythos indexer can work before staking update

### DIFF
--- a/src/mappings/era/MythosEraInfoDataSource.ts
+++ b/src/mappings/era/MythosEraInfoDataSource.ts
@@ -9,7 +9,7 @@ import {BigFromBigint} from "../utils";
 export class MythosEraInfoDataSource extends CachingEraInfoDataSource {
 
     async eraStarted(): Promise<boolean> {
-        return true
+        return api.query.collatorStaking !== undefined
     }
 
     protected async fetchEra(): Promise<number> {
@@ -18,6 +18,8 @@ export class MythosEraInfoDataSource extends CachingEraInfoDataSource {
     }
 
     protected async fetchEraStakers(): Promise<StakeTarget[]> {
+        if (!api.query.collatorStaking) return []
+
         const sessionValidators = (await api.query.session.validators()) as unknown as Vec<AccountId20>
         const sessionValidatorsSet = new Set(sessionValidators.map(it => it.toString()))
 


### PR DESCRIPTION
Tested on:

1. Mythos - skips staking operations
2. Muse - indexes staking

I think we might need to refactor `StakingStats` a little bit in the future to also check for `eraStarted` before apy calculation. Otherwise we have to dublicate `eraStarted` check in `fetchEraStakers`. Decided to not do it now since we need a quick patch