### PR TITLE
Fix/era_calculation

### DIFF
--- a/src/mappings/era/ValidatorEraInfoDataSource.ts
+++ b/src/mappings/era/ValidatorEraInfoDataSource.ts
@@ -17,30 +17,92 @@ export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
     }
 
     protected async fetchEra(): Promise<number> {
-        return (await api.query.staking.currentEra()).unwrap().toNumber()
+        const currentEra = (await api.query.staking.currentEra()).unwrap().toNumber()
+        logger.info(`[DEBUG] Current era from chain: ${currentEra}`)
+        
+        // Check if current era has data, if not use previous era
+        const currentEraOverview = await api.query.staking.erasStakersOverview.entries(currentEra)
+        logger.info(`[DEBUG] Current era ${currentEra} overview length: ${currentEraOverview.length}`)
+        
+        if (currentEraOverview.length === 0) {
+            // Current era doesn't have data yet, use previous era
+            const previousEra = currentEra - 1
+            logger.info(`[DEBUG] Current era ${currentEra} has no data, trying previous era ${previousEra}`)
+            
+            const previousEraOverview = await api.query.staking.erasStakersOverview.entries(previousEra)
+            logger.info(`[DEBUG] Previous era ${previousEra} overview length: ${previousEraOverview.length}`)
+            
+            if (previousEraOverview.length > 0) {
+                logger.info(`[DEBUG] Using previous era ${previousEra} which has data`)
+                return previousEra
+            }
+        }
+        
+        return currentEra
     }
 
     protected async fetchEraStakers(): Promise<StakeTarget[]> {
-        const era = await this.era()
+        let era = await this.era()
+        logger.info(`[DEBUG] Fetching era stakers for era: ${era}`)
         let stakers: StakeTarget[]
+        
+        // Check if paged storage is available
         if (api.query.staking.erasStakersOverview) {
+            logger.info(`[DEBUG] Paged storage available, attempting to fetch era ${era} stakers`)
             stakers = await this.fetchEraStakersPaged(era);
+            logger.info(`[DEBUG] Paged storage returned ${stakers.length} stakers for era ${era}`)
             if (stakers.length > 0) {
+                logger.info(`[DEBUG] Using paged storage results for era ${era}`)
                 return stakers
             }
-        } 
+        } else {
+            logger.info(`[DEBUG] Paged storage (erasStakersOverview) not available`)
+        }
         
+        // Fallback to clipped storage
         if (api.query.staking.erasStakersClipped) {
+            logger.info(`[DEBUG] Clipped storage available, attempting to fetch era ${era} stakers`)
             stakers = await this.fetchEraStakersClipped(era);
+            logger.info(`[DEBUG] Clipped storage returned ${stakers.length} stakers for era ${era}`)
             if (stakers.length > 0) {
+                logger.info(`[DEBUG] Using clipped storage results for era ${era}`)
                 return stakers
+            }
+        } else {
+            logger.info(`[DEBUG] Clipped storage (erasStakersClipped) not available`)
+        }
+        
+        // If no stakers found, try previous era
+        logger.warn(`[DEBUG] No stakers found for era ${era}, trying previous era`)
+        const currentEra = (await api.query.staking.currentEra()).unwrap().toNumber()
+        if (era === currentEra) {
+            const previousEra = currentEra - 1
+            logger.info(`[DEBUG] Trying previous era ${previousEra}`)
+            
+            // Clear the cached era and try previous era
+            this._era = undefined
+            era = await this.era()
+            logger.info(`[DEBUG] Now using era: ${era}`)
+            
+            // Try again with the new era
+            if (api.query.staking.erasStakersOverview) {
+                stakers = await this.fetchEraStakersPaged(era);
+                logger.info(`[DEBUG] Previous era ${era} returned ${stakers.length} stakers`)
+                if (stakers.length > 0) {
+                    logger.info(`[DEBUG] Using previous era ${era} results`)
+                    return stakers
+                }
             }
         }
+        
+        logger.warn(`[DEBUG] No stakers found for any era`)
         return stakers
     }
 
     private async fetchEraStakersClipped(era: number): Promise<StakeTarget[]> {
+        logger.info(`[DEBUG] Fetching clipped stakers for era ${era}`)
         const exposures = await api.query.staking.erasStakersClipped.entries(era)
+        logger.info(`[DEBUG] Clipped storage query returned ${exposures.length} entries for era ${era}`)
 
         return exposures.map(([key, exp]) => {
             const exposure = exp as PalletStakingExposure
@@ -64,13 +126,44 @@ export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
     }
 
     private async fetchEraStakersPaged(era: number): Promise<StakeTarget[]> {
-        logger.info(`Fetching era stakers paged for era ${era}`)
+        logger.info(`[DEBUG] Fetching era stakers paged for era ${era}`)
+        logger.info(`[DEBUG] Querying at current block height`)
+        
+        // Try querying with explicit era parameter
         const overview = await api.query.staking.erasStakersOverview.entries(era)
-        logger.info(`Overview length: ${overview.length}`)
+        logger.info(`[DEBUG] Overview length: ${overview.length} for era ${era}`)
+        
+        // Also try querying without era parameter to see what's available
+        const allOverview = await api.query.staking.erasStakersOverview.entries()
+        logger.info(`[DEBUG] Total overview entries available: ${allOverview.length}`)
+        
+        // Check what eras are available in the overview
+        if (allOverview.length > 0) {
+            const availableEras = allOverview.map(([key]) => (key.args[0] as INumber).toNumber()).sort((a, b) => b - a)
+            logger.info(`[DEBUG] Available eras in overview (latest 10): ${availableEras.slice(0, 10).join(', ')}`)
+            logger.info(`[DEBUG] Looking for era: ${era}, found: ${availableEras.includes(era)}`)
+            
+            // Check if we're querying the wrong era - maybe we should use the current era
+            const currentEra = await api.query.staking.currentEra()
+            if (currentEra.isSome) {
+                const currentEraNumber = currentEra.unwrap().toNumber()
+                logger.info(`[DEBUG] Current era from chain: ${currentEraNumber}`)
+                logger.info(`[DEBUG] Querying era: ${era}, but current era is: ${currentEraNumber}`)
+                
+                if (era !== currentEraNumber) {
+                    logger.warn(`[DEBUG] ERA MISMATCH: Querying era ${era} but current era is ${currentEraNumber}`)
+                    // Try querying the current era instead
+                    const currentEraOverview = await api.query.staking.erasStakersOverview.entries(currentEraNumber)
+                    logger.info(`[DEBUG] Current era ${currentEraNumber} overview length: ${currentEraOverview.length}`)
+                }
+            }
+        }
+        
         const pages = await api.query.staking.erasStakersPaged.entries(era)
-        logger.info(`Pages length: ${pages.length}`)
+        logger.info(`[DEBUG] Pages length: ${pages.length} for era ${era}`)
 
-        if (overview.length === 0 && pages.length === 0) {
+        if (overview.length === 0) {
+            logger.warn(`[DEBUG] Overview is empty for era ${era} - returning empty array`)
             return []
         }
     
@@ -90,15 +183,19 @@ export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
             (accumulator[validatorAddress] = accumulator[validatorAddress] || {})[pageNumber] = others;
             return accumulator;
         }, {})
+        
+        logger.info(`[DEBUG] Processed ${Object.keys(othersCounted).length} validators with page data`)
     
-        return overview.map(([key, exp]) => {
+        const result = overview.map(([key, exp]) => {
             const exposure = (exp as unknown as Option<SpStakingPagedExposureMetadata>).unwrap()
             const [, validatorId] = key.args
             let validatorAddress = validatorId.toString()
         
             let others = []
             for (let i = 0; i < exposure.pageCount.toNumber(); ++i) {
-                others.push(...othersCounted[validatorAddress][i])
+                if (othersCounted[validatorAddress] && othersCounted[validatorAddress][i]) {
+                    others.push(...othersCounted[validatorAddress][i])
+                }
             };
 
             return {
@@ -108,5 +205,8 @@ export class ValidatorEraInfoDataSource extends CachingEraInfoDataSource {
                 others: others
             }
         });
+        
+        logger.info(`[DEBUG] Paged storage processing complete for era ${era}, returning ${result.length} validators`)
+        return result;
     }
 }

--- a/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
+++ b/src/mappings/rewards/ValidatorStakingRewardCalculator.ts
@@ -66,10 +66,11 @@ export abstract class ValidatorStakingRewardCalculator implements RewardCalculat
         )
 
         return eraStakers.map(({address, totalStake}) => {
+            const commission = commissionByValidatorId[address]
             return {
                 address: address,
                 totalStake: totalStake,
-                commission: PerbillToNumber(commissionByValidatorId[address])
+                commission: commission ? PerbillToNumber(commission) : 0
             }
         })
     }


### PR DESCRIPTION
Problem occurs because new session contains 0 data about nominators on block, when new session happened:

https://assethub-westend.subscan.io/event/12924000-2

<img width="1463" height="776" alt="Screenshot 2025-10-02 at 15 52 33" src="https://github.com/user-attachments/assets/529aeae0-a18b-4cd8-8362-3775e98754b9" />
