### PR TITLE
fix:  Invulnerable collator included in Mythos staking APY calculation

### DIFF
--- a/src/mappings/era/MythosEraInfoDataSource.ts
+++ b/src/mappings/era/MythosEraInfoDataSource.ts
@@ -21,14 +21,14 @@ export class MythosEraInfoDataSource extends CachingEraInfoDataSource {
         if (!api.query.collatorStaking) return []
 
         const sessionValidators = (await api.query.session.validators()) as unknown as Vec<AccountId20>
-        const sessionValidatorsSet = new Set(sessionValidators.map(it => it.toString().toLowerCase()))
+        const sessionValidatorsSet = new Set(sessionValidators.map(it => it.toString()))
 
         const stakes = (await api.query.collatorStaking.candidateStake.entries())
 
         const stakesByCollator = groupBy(stakes,
             ([key]) => {
                 const collatorId = key.args[0]
-                return collatorId.toString().toLowerCase()
+                return collatorId.toString()
             })
 
         return Object.entries(stakesByCollator)

--- a/src/mappings/era/MythosEraInfoDataSource.ts
+++ b/src/mappings/era/MythosEraInfoDataSource.ts
@@ -21,14 +21,14 @@ export class MythosEraInfoDataSource extends CachingEraInfoDataSource {
         if (!api.query.collatorStaking) return []
 
         const sessionValidators = (await api.query.session.validators()) as unknown as Vec<AccountId20>
-        const sessionValidatorsSet = new Set(sessionValidators.map(it => it.toString()))
+        const sessionValidatorsSet = new Set(sessionValidators.map(it => it.toString().toLowerCase()))
 
         const stakes = (await api.query.collatorStaking.candidateStake.entries())
 
         const stakesByCollator = groupBy(stakes,
             ([key]) => {
                 const collatorId = key.args[0]
-                return collatorId.toString()
+                return collatorId.toString().toLowerCase()
             })
 
         return Object.entries(stakesByCollator)

--- a/src/mappings/rewards/MythosRewardCalculator.ts
+++ b/src/mappings/rewards/MythosRewardCalculator.ts
@@ -20,10 +20,10 @@ export class MythosRewardCalculator implements RewardCalculator {
         const minStake = (await api.query.collatorStaking.minStake()) as unknown as INumber
 
         const invulnerablesRaw = await api.query.collatorStaking.invulnerables()
-        const invulnerablesSet = new Set((invulnerablesRaw as unknown as any[]).map((addr: any) => addr.toString().toLowerCase()))
+        const invulnerablesSet = new Set((invulnerablesRaw as unknown as any[]).map((addr: any) => addr.toString()))
 
         // Invulnerables do not earn staking rewards — exclude them from APR calculation
-        const rewardableCollators = allSessionCollators.filter(c => !invulnerablesSet.has(c.address.toLowerCase()))
+        const rewardableCollators = allSessionCollators.filter(c => !invulnerablesSet.has(c.address))
 
         logger.info(`[MythosAPR] perBlockReward=${perBlockReward.toString()}, blocksPerYear=${blocksPerYear}, sessionCollators=${allSessionCollators.length}, rewardable=${rewardableCollators.length}, invulnerables=${invulnerablesSet.size}, commission=${collatorCommission}, minStake=${minStake.toString()}`)
 

--- a/src/mappings/rewards/MythosRewardCalculator.ts
+++ b/src/mappings/rewards/MythosRewardCalculator.ts
@@ -15,14 +15,24 @@ export class MythosRewardCalculator implements RewardCalculator {
     async maxApy(): Promise<number> {
         const perBlockReward = (await api.query.collatorStaking.extraReward()) as unknown as INumber
         const blocksPerYear = this.blocksInYear()
-        const activeCollators = await this.eraInfoDataSource.eraStakers()
+        const allSessionCollators = await this.eraInfoDataSource.eraStakers()
         const collatorCommission = ((await api.query.collatorStaking.collatorRewardPercentage()) as unknown as Percent).toNumber()
         const minStake = (await api.query.collatorStaking.minStake()) as unknown as INumber
 
+        const invulnerablesRaw = await api.query.collatorStaking.invulnerables()
+        const invulnerablesSet = new Set((invulnerablesRaw as unknown as any[]).map((addr: any) => addr.toString().toLowerCase()))
+
+        // Invulnerables do not earn staking rewards — exclude them from APR calculation
+        const rewardableCollators = allSessionCollators.filter(c => !invulnerablesSet.has(c.address.toLowerCase()))
+
+        logger.info(`[MythosAPR] perBlockReward=${perBlockReward.toString()}, blocksPerYear=${blocksPerYear}, sessionCollators=${allSessionCollators.length}, rewardable=${rewardableCollators.length}, invulnerables=${invulnerablesSet.size}, commission=${collatorCommission}, minStake=${minStake.toString()}`)
+
+        if (rewardableCollators.length === 0) return 0.0
+
         const yearlyEmission = BigFromINumber(perBlockReward).mul(blocksPerYear)
 
-        const collatorAPRs = activeCollators.map((stakeTarget) => {
-            const perCollatorRewards = yearlyEmission.div(activeCollators.length).mul(1 - collatorCommission / 100)
+        const collatorAPRs = rewardableCollators.map((stakeTarget) => {
+            const perCollatorRewards = yearlyEmission.div(rewardableCollators.length).mul(1 - collatorCommission / 100)
             const apr = perCollatorRewards.div(stakeTarget.totalStake.add(BigFromINumber(minStake)))
             return apr.toNumber()
         })


### PR DESCRIPTION
https://github.com/novasamatech/subquery-staking/issues/100

# Root cause

`MythosRewardCalculator` was computing max APY over all session validators, including invulnerables. On the Mythos network there is currently 1 invulnerable collator which happens to have the smallest total stake (~2.3M MYTH) of all active collators — making it produce the highest APR value and dominate the result.

However, the Mythos `collator-staking` pallet does **not** reward invulnerable collators: blocks produced by invulnerables only increment `TotalBlocks`, not `ProducedBlocks`. Since rewards are distributed proportionally from `ProducedBlocks`, invulnerables and their delegators receive nothing.

This caused SubQuery to report `maxAPY = 3.26` while the iOS app showed `1.18`.

## iOS reference

The iOS app correctly excludes invulnerables via the `rewardable` property:

[`MythosSessionCollators.swift`](https://github.com/novasamatech/nova-wallet-ios/blob/master/novawallet/Modules/Staking/Services/EraValidatorsService/MythosStaking/MythosSessionCollators.swift)
```swift
var rewardable: Bool {
    !invulnerable
}
```

Used in [`MythosRewardCalculatorEngine.swift`](https://github.com/novasamatech/nova-wallet-ios/blob/master/novawallet/Modules/Staking/Services/RewardCalculatorService/MythosStaking/MythosRewardCalculatorEngine.swift#L33):
```swift
let rewardableCollators = params.collators.filter(rewardable)
let rewardableCollatorsCount = rewardableCollators.count
// yearly emission is divided by rewardableCollatorsCount, not total session validators
```

## Fix

`MythosRewardCalculator.maxApy()` now fetches `collatorStaking.invulnerables()` and filters them out before computing APRs. Both the emission divisor and the max APR search use only rewardable (non-invulnerable) collators — matching the iOS formula exactly.


## Tested

<img width="1080" height="288" alt="Screenshot 2026-03-26 at 13 40 07" src="https://github.com/user-attachments/assets/359c76ec-8f14-451d-b191-14c110c2ee17" />
<img width="915" height="204" alt="Screenshot 2026-03-26 at 13 41 32" src="https://github.com/user-attachments/assets/8ef7ce9b-756e-4a25-a6fe-cdc16689c89f" />


