### PR TITLE
fix: Replace hardcoded era mint with reward curve inflation

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -21,7 +21,7 @@ services:
     build:
       context: .
     container_name: "node-${PROJECT_PATH}"
-    image: subquerynetwork/subql-node-substrate:v5.6.0
+    image: subquerynetwork/subql-node-substrate:v6.4.6
     depends_on:
       "postgres":
         condition: service_healthy

--- a/src/mappings/rewards/inflation/PolkadotNewStakingInflation.ts
+++ b/src/mappings/rewards/inflation/PolkadotNewStakingInflation.ts
@@ -1,12 +1,31 @@
 import {Inflation, StakedInfo} from "./Inflation";
 import Big from "big.js";
+import type {Codec, INumber, ITuple} from "@polkadot/types-codec/types";
+import {BigFromINumber} from "../../utils";
+
+const ERAS_PER_YEAR = 365
+
+// Fallback: last known era mint to stakers (used when inflation pallet is unavailable)
+const FALLBACK_ERA_MINT_TO_STAKERS = Big(229_697_909_865_732)
+
+interface IssuancePredictionInfo extends Codec {
+    readonly nextMint: ITuple<[INumber, INumber]>
+}
 
 export class PolkadotStakingInflation implements Inflation {
 
     async from(stakedInfo: StakedInfo): Promise<number> {
-        let era_mint = Big(2_794_778_104_198_508)
-        let inflation = era_mint.mul(365).div(stakedInfo.totalIssuance).toNumber()
+        const eraMint = await this.fetchEraMintToStakers()
+        return eraMint.mul(ERAS_PER_YEAR).div(stakedInfo.totalIssuance).toNumber()
+    }
 
-        return inflation
+    private async fetchEraMintToStakers(): Promise<Big> {
+        try {
+            const info = await api.call.inflation.experimentalIssuancePredictionInfo() as IssuancePredictionInfo
+            return BigFromINumber(info.nextMint[0])
+        } catch {
+            logger.warn('Inflation pallet unavailable, falling back to hardcoded era mint')
+            return FALLBACK_ERA_MINT_TO_STAKERS
+        }
     }
 }


### PR DESCRIPTION
PolkadotNewStakingInflation used a hardcoded era_mint = 2_794_778_104_198_508 - replaced it with actual call runtime call and safety fall back for old blocks indexation


<img width="1382" height="828" alt="Screenshot 2026-03-26 at 18 29 07" src="https://github.com/user-attachments/assets/5bb818fb-f368-4e11-87a2-c79be75f201d" />

