### PR TITLE
Fix: snapshot activeEra on EraPaid — election page-0 events are gone on new runtimes

### DIFF
--- a/project-kusama-ah.yaml
+++ b/project-kusama-ah.yaml
@@ -24,11 +24,11 @@ dataSources:
     mapping:
       file: ./dist/index.js
       handlers:
-        - handler: handleKusamaAHPagedElectionProceeded
+        - handler: handleKusamaAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
 
         - handler: handleKusamaAHStakingReward
           kind: substrate/EventHandler

--- a/project-polkadot-ah.yaml
+++ b/project-polkadot-ah.yaml
@@ -25,11 +25,11 @@ dataSources:
     mapping:
       file: ./dist/index.js
       handlers:
-        - handler: handlePolkadotAHPagedElectionProceeded
+        - handler: handlePolkadotAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
 
         - handler: handlePolkadotAHStakingReward
           kind: substrate/EventHandler

--- a/project-westend-ah.yaml
+++ b/project-westend-ah.yaml
@@ -25,11 +25,11 @@ dataSources:
     mapping:
       file: ./dist/index.js
       handlers:
-        - handler: handleWestendAHPagedElectionProceeded
+        - handler: handleWestendAHEraPaid
           kind: substrate/EventHandler
           filter:
             module: staking
-            method: PagedElectionProceeded
+            method: EraPaid
 
         - handler: handleWestendAHStakingReward
           kind: substrate/EventHandler

--- a/src/mappings/era/ActiveEraValidatorEraInfoDataSource.ts
+++ b/src/mappings/era/ActiveEraValidatorEraInfoDataSource.ts
@@ -2,18 +2,18 @@ import { ValidatorEraInfoDataSource } from "./ValidatorEraInfoDataSource";
 import type { PalletStakingActiveEraInfo } from "@polkadot/types/lookup";
 import type { Option } from "@polkadot/types-codec";
 
-// staking-async (Asset Hub). How the chain rotates eras (see Rotator/EraElectionPlanner in
-// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/staking-async/src/session_rotation.rs):
+// staking-async (Asset Hub). How the chain rotates eras (Rotator/EraElectionPlanner in pallet-staking-async):
+// https://github.com/paritytech/polkadot-sdk/blob/470d1ad2a82c95c28c825412cb636aed4f54b83e/substrate/frame/staking-async/src/session_rotation.rs
 //
-// 1. `plan_new_era` bumps currentEra mid-era (planning deadline), so at any rotation
+// 1. `plan_new_era` (#L1018) bumps currentEra mid-era (planning deadline), so at any rotation
 //    currentEra already points to the NEXT planned era with no exposures in state.
 // 2. The multi-block election pulls pages msp..0; exposures are stored per page only
-//    on the Ok path of `do_elect_paged`. `PagedElectionProceeded` is emitted per elect()
+//    on the Ok path of `do_elect_paged` (#L1178). `PagedElectionProceeded` is emitted per elect()
 //    attempt: newer runtimes skip page 0 on the success path and emit the full failed
 //    range with `result: Err`, so election events are NOT a reliable trigger.
 // 3. The validator set is sent to the relay chain only after the last election page,
 //    and only then the era can be activated: `Rotator::start_era` emits EraPaid (in both
-//    legacy and DAP end-era paths) and increments activeEra.
+//    legacy and DAP end-era paths) and increments activeEra (`start_era`, #L860).
 //
 // Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
 // cannot start without its full validator set.

--- a/src/mappings/era/ActiveEraValidatorEraInfoDataSource.ts
+++ b/src/mappings/era/ActiveEraValidatorEraInfoDataSource.ts
@@ -1,0 +1,24 @@
+import { ValidatorEraInfoDataSource } from "./ValidatorEraInfoDataSource";
+import type { PalletStakingActiveEraInfo } from "@polkadot/types/lookup";
+import type { Option } from "@polkadot/types-codec";
+
+// staking-async (Asset Hub): at the EraPaid rotation block currentEra already
+// points to the next planned era whose exposures are not on-chain yet, while
+// the era that just became active always has its full exposure set in state.
+export class ActiveEraValidatorEraInfoDataSource extends ValidatorEraInfoDataSource {
+  async eraStarted(): Promise<boolean> {
+    if (
+      api.query["staking"] === undefined ||
+      typeof api.query.staking["activeEra"] !== "function"
+    ) {
+      return false;
+    }
+    const era = (await api.query.staking.activeEra()) as unknown as Option<PalletStakingActiveEraInfo>;
+    return era.isSome && (this._era = era.unwrap().index.toNumber()) > 0;
+  }
+
+  protected async fetchEra(): Promise<number> {
+    const era = (await api.query.staking.activeEra()) as unknown as Option<PalletStakingActiveEraInfo>;
+    return era.unwrap().index.toNumber();
+  }
+}

--- a/src/mappings/era/ActiveEraValidatorEraInfoDataSource.ts
+++ b/src/mappings/era/ActiveEraValidatorEraInfoDataSource.ts
@@ -2,9 +2,21 @@ import { ValidatorEraInfoDataSource } from "./ValidatorEraInfoDataSource";
 import type { PalletStakingActiveEraInfo } from "@polkadot/types/lookup";
 import type { Option } from "@polkadot/types-codec";
 
-// staking-async (Asset Hub): at the EraPaid rotation block currentEra already
-// points to the next planned era whose exposures are not on-chain yet, while
-// the era that just became active always has its full exposure set in state.
+// staking-async (Asset Hub). How the chain rotates eras (see Rotator/EraElectionPlanner in
+// https://github.com/paritytech/polkadot-sdk/blob/master/substrate/frame/staking-async/src/session_rotation.rs):
+//
+// 1. `plan_new_era` bumps currentEra mid-era (planning deadline), so at any rotation
+//    currentEra already points to the NEXT planned era with no exposures in state.
+// 2. The multi-block election pulls pages msp..0; exposures are stored per page only
+//    on the Ok path of `do_elect_paged`. `PagedElectionProceeded` is emitted per elect()
+//    attempt: newer runtimes skip page 0 on the success path and emit the full failed
+//    range with `result: Err`, so election events are NOT a reliable trigger.
+// 3. The validator set is sent to the relay chain only after the last election page,
+//    and only then the era can be activated: `Rotator::start_era` emits EraPaid (in both
+//    legacy and DAP end-era paths) and increments activeEra.
+//
+// Therefore at the EraPaid block exposures(activeEra) are guaranteed complete - an era
+// cannot start without its full validator set.
 export class ActiveEraValidatorEraInfoDataSource extends ValidatorEraInfoDataSource {
   async eraStarted(): Promise<boolean> {
     if (

--- a/src/mappings/kusama-ah.ts
+++ b/src/mappings/kusama-ah.ts
@@ -2,7 +2,7 @@ import {SubstrateEvent} from "@subql/types";
 import {handleEraAssetHub, POOLED_STAKING_TYPE} from "./common";
 import {RelaychainRewardCalculator} from "./rewards/Relaychain";
 import {NominationPoolRewardCalculator} from "./rewards/NominationPoolRewardCalculator";
-import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
+import {ActiveEraValidatorEraInfoDataSource} from "./era/ActiveEraValidatorEraInfoDataSource";
 import type {Codec} from "@polkadot/types-codec/types";
 import type {INumber} from "@polkadot/types-codec/types";
 import {handleRelaychainStakingReward, handleRelaychainStakingSlash} from "./rewards/history/relaychain";
@@ -11,16 +11,15 @@ import {
     handleRelaychainPooledStakingBondedSlash,
     handleRelaychainPooledStakingUnbondingSlash
 } from "./rewards/history/nomination_pools";
-import {shouldProcessPageIndex} from "./utils";
 
 const KUSAMA_AH_GENESIS = "0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a"
 const DIRECT_STAKING_TYPE = "relaychain"
 
-export async function handleKusamaAHPagedElectionProceeded(event: SubstrateEvent): Promise<void> {
-    if (!shouldProcessPageIndex(event)) {
-        return;
-    }
-    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+// staking-async: PagedElectionProceeded is not emitted for every page on the
+// success path anymore, while EraPaid still fires at every rotation and the
+// just-started active era always has complete exposures in state.
+export async function handleKusamaAHEraPaid(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ActiveEraValidatorEraInfoDataSource();
     let mainRewardCalculator = await RelaychainRewardCalculator(validatorEraInfoDataSource)
     let poolRewardCalculator = new NominationPoolRewardCalculator(validatorEraInfoDataSource, mainRewardCalculator)
 

--- a/src/mappings/kusama-ah.ts
+++ b/src/mappings/kusama-ah.ts
@@ -15,9 +15,10 @@ import {
 const KUSAMA_AH_GENESIS = "0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a"
 const DIRECT_STAKING_TYPE = "relaychain"
 
-// staking-async: PagedElectionProceeded is not emitted for every page on the
-// success path anymore, while EraPaid still fires at every rotation and the
-// just-started active era always has complete exposures in state.
+// staking-async: PagedElectionProceeded is not emitted for every page on the success
+// path anymore, while EraPaid fires at every rotation and the just-started active era
+// always has complete exposures in state - see ActiveEraValidatorEraInfoDataSource for
+// the polkadot-sdk reference and details.
 export async function handleKusamaAHEraPaid(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ActiveEraValidatorEraInfoDataSource();
     let mainRewardCalculator = await RelaychainRewardCalculator(validatorEraInfoDataSource)

--- a/src/mappings/polkadot-ah.ts
+++ b/src/mappings/polkadot-ah.ts
@@ -22,9 +22,10 @@ export async function PolkadotAHRewardCalculator(eraInfoDataSource: EraInfoDataS
     return CustomPolkadotRewardCalculator(eraInfoDataSource)
 }
 
-// staking-async: PagedElectionProceeded is not emitted for every page on the
-// success path anymore, while EraPaid still fires at every rotation and the
-// just-started active era always has complete exposures in state.
+// staking-async: PagedElectionProceeded is not emitted for every page on the success
+// path anymore, while EraPaid fires at every rotation and the just-started active era
+// always has complete exposures in state - see ActiveEraValidatorEraInfoDataSource for
+// the polkadot-sdk reference and details.
 export async function handlePolkadotAHEraPaid(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ActiveEraValidatorEraInfoDataSource();
     let mainRewardCalculator = await PolkadotAHRewardCalculator(validatorEraInfoDataSource)

--- a/src/mappings/polkadot-ah.ts
+++ b/src/mappings/polkadot-ah.ts
@@ -3,7 +3,7 @@ import {handleEraAssetHub, POOLED_STAKING_TYPE} from "./common";
 import {CustomPolkadotRewardCalculator} from "./rewards/Relaychain";
 import {NominationPoolRewardCalculator} from "./rewards/NominationPoolRewardCalculator";
 import {ValidatorStakingRewardCalculator} from "./rewards/ValidatorStakingRewardCalculator";
-import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
+import {ActiveEraValidatorEraInfoDataSource} from "./era/ActiveEraValidatorEraInfoDataSource";
 import {EraInfoDataSource} from "./era/EraInfoDataSource";
 import type {Codec} from "@polkadot/types-codec/types";
 import type {INumber} from "@polkadot/types-codec/types";
@@ -13,7 +13,6 @@ import {
     handleRelaychainPooledStakingBondedSlash,
     handleRelaychainPooledStakingUnbondingSlash
 } from "./rewards/history/nomination_pools";
-import {shouldProcessPageIndex} from "./utils";
 
 const POLKADOT_AH_GENESIS = "0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f"
 const DIRECT_STAKING_TYPE = "relaychain"
@@ -23,11 +22,11 @@ export async function PolkadotAHRewardCalculator(eraInfoDataSource: EraInfoDataS
     return CustomPolkadotRewardCalculator(eraInfoDataSource)
 }
 
-export async function handlePolkadotAHPagedElectionProceeded(event: SubstrateEvent): Promise<void> {
-    if (!shouldProcessPageIndex(event)) {
-        return;
-    }
-    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+// staking-async: PagedElectionProceeded is not emitted for every page on the
+// success path anymore, while EraPaid still fires at every rotation and the
+// just-started active era always has complete exposures in state.
+export async function handlePolkadotAHEraPaid(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ActiveEraValidatorEraInfoDataSource();
     let mainRewardCalculator = await PolkadotAHRewardCalculator(validatorEraInfoDataSource)
     let poolRewardCalculator = new NominationPoolRewardCalculator(validatorEraInfoDataSource, mainRewardCalculator)
 

--- a/src/mappings/utils.ts
+++ b/src/mappings/utils.ts
@@ -2,7 +2,6 @@ import type {INumber} from "@polkadot/types-codec/types";
 import {Big} from "big.js"
 import {Perbill, Percent, AccountId32} from "@polkadot/types/interfaces/runtime/types";
 import {Compact, Struct, Vec} from '@polkadot/types-codec'
-import {SubstrateEvent} from "@subql/types";
 
 export function BigFromINumber(number: INumber): Big {
     return Big(number.toString())
@@ -91,9 +90,4 @@ export interface SpStakingExposurePage extends Struct {
     readonly pageTotal: INumber;
     readonly others: Vec<SpStakingIndividualExposure>;
 }
-
-/**
- * Checks if the page index from PagedElectionProceeded event is 0.
- * Returns true if page index is 0 (should process), false otherwise (should skip).
- */
 

--- a/src/mappings/utils.ts
+++ b/src/mappings/utils.ts
@@ -96,11 +96,4 @@ export interface SpStakingExposurePage extends Struct {
  * Checks if the page index from PagedElectionProceeded event is 0.
  * Returns true if page index is 0 (should process), false otherwise (should skip).
  */
-export function shouldProcessPageIndex(event: SubstrateEvent): boolean {
-    const page_index = event.event.data[0].toString();
-    if (page_index !== "0") {
-        logger.info(`Page index is not 0, it is ${page_index}, skipping in order to process only whole data in era`);
-        return false;
-    }
-    return true;
-}
+

--- a/src/mappings/westend-ah.ts
+++ b/src/mappings/westend-ah.ts
@@ -2,7 +2,7 @@ import {SubstrateEvent} from "@subql/types";
 import {handleEraAssetHub, POOLED_STAKING_TYPE} from "./common";
 import {RelaychainRewardCalculator} from "./rewards/Relaychain";
 import {NominationPoolRewardCalculator} from "./rewards/NominationPoolRewardCalculator";
-import {ValidatorEraInfoDataSource} from "./era/ValidatorEraInfoDataSource";
+import {ActiveEraValidatorEraInfoDataSource} from "./era/ActiveEraValidatorEraInfoDataSource";
 import type {Codec} from "@polkadot/types-codec/types";
 import type {INumber} from "@polkadot/types-codec/types";
 import {handleRelaychainStakingReward, handleRelaychainStakingSlash} from "./rewards/history/relaychain";
@@ -11,16 +11,15 @@ import {
     handleRelaychainPooledStakingBondedSlash,
     handleRelaychainPooledStakingUnbondingSlash
 } from "./rewards/history/nomination_pools";
-import {shouldProcessPageIndex} from "./utils";
 
 const WESTEND_AH_GENESIS = "0x67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9"
 const DIRECT_STAKING_TYPE = "relaychain"
 
-export async function handleWestendAHPagedElectionProceeded(event: SubstrateEvent): Promise<void> {
-    if (!shouldProcessPageIndex(event)) {
-        return;
-    }
-    let validatorEraInfoDataSource = new ValidatorEraInfoDataSource();
+// staking-async: PagedElectionProceeded is not emitted for every page on the
+// success path anymore, while EraPaid still fires at every rotation and the
+// just-started active era always has complete exposures in state.
+export async function handleWestendAHEraPaid(_: SubstrateEvent): Promise<void> {
+    let validatorEraInfoDataSource = new ActiveEraValidatorEraInfoDataSource();
     let mainRewardCalculator = await RelaychainRewardCalculator(validatorEraInfoDataSource)
     let poolRewardCalculator = new NominationPoolRewardCalculator(validatorEraInfoDataSource, mainRewardCalculator)
 

--- a/src/mappings/westend-ah.ts
+++ b/src/mappings/westend-ah.ts
@@ -15,9 +15,10 @@ import {
 const WESTEND_AH_GENESIS = "0x67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9"
 const DIRECT_STAKING_TYPE = "relaychain"
 
-// staking-async: PagedElectionProceeded is not emitted for every page on the
-// success path anymore, while EraPaid still fires at every rotation and the
-// just-started active era always has complete exposures in state.
+// staking-async: PagedElectionProceeded is not emitted for every page on the success
+// path anymore, while EraPaid fires at every rotation and the just-started active era
+// always has complete exposures in state - see ActiveEraValidatorEraInfoDataSource for
+// the polkadot-sdk reference and details.
 export async function handleWestendAHEraPaid(_: SubstrateEvent): Promise<void> {
     let validatorEraInfoDataSource = new ActiveEraValidatorEraInfoDataSource();
     let mainRewardCalculator = await RelaychainRewardCalculator(validatorEraInfoDataSource)

--- a/tests/activeEraDataSource.test.ts
+++ b/tests/activeEraDataSource.test.ts
@@ -1,0 +1,103 @@
+import { ActiveEraValidatorEraInfoDataSource } from "../src/mappings/era/ActiveEraValidatorEraInfoDataSource";
+import { mockOption, mockNumber, mockAddress } from "./utils/mockFunctions";
+
+const ACTIVE_ERA = 2227;
+const PLANNED_ERA = 2228;
+
+const VALIDATOR = "14LzEeAqYAgVvbxqzdVQGL8zPQFe1o5zGRSbCZDwtCd2AZgA";
+const NOMINATOR_1 = "136fZX6JHbywxoMXZiTY23eGGGkb3HrW7UHWZvZ5JGLzSGNF";
+const NOMINATOR_2 = "14UpRGUeAfsSZHFN63t4ojJrLNupPApUiLgovXtm7ZiAHUDA";
+
+// At the EraPaid rotation block: exposures exist only for the era that just
+// became active, currentEra already points to the next planned era.
+const mockAPI = {
+  query: {
+    staking: {
+      activeEra: async () =>
+        mockOption({ index: mockNumber(ACTIVE_ERA), start: mockOption(0) }),
+      currentEra: async () => mockOption(mockNumber(PLANNED_ERA)),
+      erasStakersOverview: {
+        entries: async (era: number) =>
+          era === ACTIVE_ERA
+            ? [
+                [
+                  { args: [mockNumber(ACTIVE_ERA), mockAddress(VALIDATOR)] },
+                  mockOption({
+                    total: mockNumber(3000),
+                    own: mockNumber(1000),
+                    pageCount: mockNumber(2),
+                  }),
+                ],
+              ]
+            : [],
+      },
+      erasStakersPaged: {
+        entries: async (era: number) =>
+          era === ACTIVE_ERA
+            ? [
+                [
+                  {
+                    args: [
+                      mockNumber(ACTIVE_ERA),
+                      mockAddress(VALIDATOR),
+                      mockNumber(0),
+                    ],
+                  },
+                  mockOption({
+                    others: [
+                      { who: mockAddress(NOMINATOR_1), value: mockNumber(500) },
+                    ],
+                  }),
+                ],
+                [
+                  {
+                    args: [
+                      mockNumber(ACTIVE_ERA),
+                      mockAddress(VALIDATOR),
+                      mockNumber(1),
+                    ],
+                  },
+                  mockOption({
+                    others: [
+                      { who: mockAddress(NOMINATOR_2), value: mockNumber(1500) },
+                    ],
+                  }),
+                ],
+              ]
+            : [],
+      },
+    },
+  },
+};
+
+describe("ActiveEraValidatorEraInfoDataSource", () => {
+  beforeAll(() => {
+    (global as any).api = mockAPI;
+    (global as any).logger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+  });
+
+  it("resolves era to activeEra, not the planned currentEra", async () => {
+    const dataSource = new ActiveEraValidatorEraInfoDataSource();
+
+    expect(await dataSource.eraStarted()).toBe(true);
+    expect(await dataSource.era()).toBe(ACTIVE_ERA);
+  });
+
+  it("fetches full paged exposures of the active era", async () => {
+    const dataSource = new ActiveEraValidatorEraInfoDataSource();
+
+    const stakers = await dataSource.eraStakers();
+
+    expect(stakers).toHaveLength(1);
+    expect(stakers[0].address).toBe(VALIDATOR);
+    expect(stakers[0].selfStake).toBe(BigInt(1000));
+    expect(stakers[0].others.map((other) => other.address)).toEqual([
+      NOMINATOR_1,
+      NOMINATOR_2,
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

Prod AH staking stats have been silently degrading network by network, following the runtime rollout order:

| Network | ActiveStaker data |
|---|---|
| Westend AH | stale for >3 weeks |
| Kusama AH | frozen at era **9728** (~June 30) |
| Polkadot AH | still fresh — breaks with its next runtime upgrade |

Root cause: recent staking-async runtimes no longer emit `PagedElectionProceeded` for every page on the **success** path. In 24h of kusama-ah pod logs there is exactly one election event — page 14, skipped by `shouldProcessPageIndex` ("Page index is not 0 ... skipping"). Westend AH emits the full `31..0` range only for **failed** election attempts (`result: Err(0)`). Page 0 never arrives on the success path, so the #98 trigger is dead.

## Fix

Trigger on `staking.EraPaid` (still fires at every rotation) and read **activeEra** instead of `currentEra`: at the rotation block `currentEra` already points to the next planned era with no exposures in state, while the era that just became active cannot have started without its full exposure set. Verified on-chain at the rotation blocks: Polkadot AH `exposures(2227)=600`, Kusama AH `exposures(9780)=700`, Westend AH rotation block carries `EraPaid`.

- new `ActiveEraValidatorEraInfoDataSource` (activeEra-based era resolution), used by the three AH handlers
- `handle<Net>AHPagedElectionProceeded` → `handle<Net>AHEraPaid`, project yamls updated
- `shouldProcessPageIndex` removed (dead)

No backfill needed here: ActiveStaker/StakingApy are point-in-time — the first era after deployment fully refreshes them.

Same fix for subquery-history (which shares the trigger pattern): novasamatech/subquery-history#338.

## Verification

- new `tests/activeEraDataSource.test.ts`: era resolves to activeEra (not planned currentEra), paged exposures merge across pages; `yarn test` 7/7
- `yarn codegen && yarn build` pass
