### PR TITLE
Fix Polkadot AH staking APY: derive from the recorded era reward allocation

### DIFF
--- a/src/mappings/rewards/inflation/PolkadotNewStakingInflation.ts
+++ b/src/mappings/rewards/inflation/PolkadotNewStakingInflation.ts
@@ -1,15 +1,13 @@
 import {Inflation, StakedInfo} from "./Inflation";
 import Big from "big.js";
-import type {Codec, INumber, ITuple} from "@polkadot/types-codec/types";
+import type {Codec, INumber} from "@polkadot/types-codec/types";
+import type {Option} from "@polkadot/types-codec";
 import {BigFromINumber} from "../../utils";
 
 const ERAS_PER_YEAR = 365
 
-// Fallback: last known era mint to stakers (used when inflation pallet is unavailable)
-const FALLBACK_ERA_MINT_TO_STAKERS = Big(229_697_909_865_732)
-
-interface IssuancePredictionInfo extends Codec {
-    readonly nextMint: ITuple<[INumber, INumber]>
+interface ActiveEraInfo extends Codec {
+    readonly index: INumber
 }
 
 export class PolkadotStakingInflation implements Inflation {
@@ -19,13 +17,30 @@ export class PolkadotStakingInflation implements Inflation {
         return eraMint.mul(ERAS_PER_YEAR).div(stakedInfo.totalIssuance).toNumber()
     }
 
+    // The staker allocation recorded by the staking pallet for the last completed era
+    // (`Staking.ErasValidatorReward` - the same figure the pallet's `era_reward_allocation`
+    // view function exposes to clients).
+    //
+    // Since the Dynamic Allocation Pool (DAP) reform only the staker allocation of the period
+    // mint (currently 45.2% of the ~153,132 DOT daily emission, ~69,216 DOT) is paid to
+    // stakers. The `Inflation.experimental_issuance_prediction_info` runtime api reports the
+    // FULL era emission in `next_mint[0]` on Polkadot since fellows-runtimes v2.3.0, so it
+    // must not be used as the staker mint (it overstates the reward pool by 1 / 0.452 ~ 2.21x).
+    // Reading the recorded allocation needs no hardcoded split and tracks both the issuance
+    // curve (ref 1710) and any governance re-allocation of the DAP budget automatically.
     private async fetchEraMintToStakers(): Promise<Big> {
-        try {
-            const info = await api.call.inflation.experimentalIssuancePredictionInfo() as IssuancePredictionInfo
-            return BigFromINumber(info.nextMint[0])
-        } catch {
-            logger.warn('Inflation pallet unavailable, falling back to hardcoded era mint')
-            return FALLBACK_ERA_MINT_TO_STAKERS
+        const activeEraOption = (await api.query.staking.activeEra()) as Option<ActiveEraInfo>
+        const activeEra = activeEraOption.unwrap().index.toNumber()
+
+        // the allocation is snapshotted at era end, so the active era itself is not recorded yet
+        const rewardOption = (await api.query.staking.erasValidatorReward(activeEra - 1)) as Option<INumber>
+
+        if (rewardOption.isNone) {
+            // Fail the handler rather than storing a wrong rate - the previously stored
+            // apy stays served and the next era retries.
+            throw new Error(`ErasValidatorReward is not recorded for era ${activeEra - 1}`)
         }
+
+        return BigFromINumber(rewardOption.unwrap())
     }
 }

--- a/tests/inflation.test.ts
+++ b/tests/inflation.test.ts
@@ -1,0 +1,71 @@
+import { PolkadotStakingInflation } from "../src/mappings/rewards/inflation/PolkadotNewStakingInflation";
+import { StakedInfo } from "../src/mappings/rewards/inflation/Inflation";
+import { mockOption, mockNumber } from "./utils/mockFunctions";
+import Big from "big.js";
+
+// Realistic post-DAP snapshot (verified on Polkadot Asset Hub, era ~2230):
+//   Staking.ErasValidatorReward[2229] = 69,215.6368394402 DOT (the DAP staker allocation,
+//                                       45.2% of the ~153,132 DOT daily mint)
+//   total staked                      = 862,000,000 DOT
+//   total issuance                    = 1,693,000,000 DOT
+// True average return = 69,216 * 365 / 862,000,000 = 2.93%.
+//
+// Regression guard: the previous implementation used the Inflation runtime api's full
+// next_mint (~153,132 DOT) as if it all went to stakers - a 2.21x (= 1 / 0.452)
+// overstatement that produced the ~8.79% max apy served until 2026-07.
+const ERA_REWARD_PLANKS = 692156368394402;
+
+const DOT = (whole: number) => Big(whole).mul(Big(10).pow(10));
+
+const mockNone = { isNone: true, isSome: false, unwrap: () => { throw new Error("Option is None"); } };
+
+const mockAPI = {
+  query: {
+    staking: {
+      activeEra: async () => mockOption({ index: mockNumber(2230) }),
+      erasValidatorReward: async (era: number) =>
+        era === 2229 ? mockOption(mockNumber(ERA_REWARD_PLANKS)) : mockNone,
+    },
+  },
+};
+
+describe("PolkadotStakingInflation", () => {
+  beforeAll(() => {
+    (global as any).api = mockAPI;
+  });
+
+  it("derives inflation from the last completed era's staker allocation", async () => {
+    const stakedInfo: StakedInfo = {
+      totalIssuance: DOT(1_693_000_000),
+      totalStaked: DOT(862_000_000),
+      stakedPortion: 862_000_000 / 1_693_000_000,
+    };
+
+    const inflation = await new PolkadotStakingInflation().from(stakedInfo);
+
+    // inflation vs issuance; the calculator divides by stakedPortion downstream,
+    // yielding the ~2.93% average staker return
+    const averageReturn = inflation / stakedInfo.stakedPortion;
+
+    expect(averageReturn).toBeCloseTo(0.0293, 4);
+  });
+
+  it("fails instead of storing a rate when the era allocation is missing", async () => {
+    (global as any).api = {
+      query: {
+        staking: {
+          activeEra: async () => mockOption({ index: mockNumber(1) }),
+          erasValidatorReward: async () => mockNone,
+        },
+      },
+    };
+
+    await expect(new PolkadotStakingInflation().from({
+      totalIssuance: DOT(1_693_000_000),
+      totalStaked: DOT(862_000_000),
+      stakedPortion: 0.5,
+    })).rejects.toThrow();
+
+    (global as any).api = mockAPI;
+  });
+});


### PR DESCRIPTION

## Problem

The `stakingApies` endpoint serves ~8.79% max APY for Polkadot Asset Hub relaychain staking (~7.94% pools) while the actual figure is ~3.97% (~3.62% pools). This feeds the staking dashboard cards in the mobile apps.

Since the Dynamic Allocation Pool (DAP) reform, only the staker allocation of the period mint (currently 45.2%) is paid to stakers. `PolkadotStakingInflation` uses the `Inflation` runtime api's `next_mint[0]` as the staker mint — but fellows-runtimes v2.3.0 (2026-06-05) redefined that value on Polkadot from "amount to stakers" to "total era emission" (~153,132 DOT/day), with the split applied downstream by pallet-dap. Same type, new meaning — a 2.21× (= 1/0.452) overstatement of the reward pool.

## Fix

Read the staker allocation the staking pallet records at era end instead:

```ts
const activeEra = (await api.query.staking.activeEra()).unwrap().index.toNumber()
const reward = await api.query.staking.erasValidatorReward(activeEra - 1)
```

`Staking.ErasValidatorReward` is the exact per-era staker budget payouts draw from — and the same figure the pallet's `era_reward_allocation` view function exposes to clients, so the indexer and the app-side fixes (novasamatech/nova-wallet-ios#1836, novasamatech/nova-wallet-android#2292) share one on-chain source of truth. No hardcoded split; tracks the ref-1710 issuance curve and any governance re-allocation of the DAP budget automatically. `activeEra − 1` because the allocation is snapshotted at era completion (the handler runs on `PagedElectionProceeded`, mid-era, so it is always recorded by then).

A missing allocation now fails the handler — the previously stored APY stays served and the next era retries — replacing the stale hardcoded fallback mint.

Downstream math (`DefaultValidatorStakingRewardCalculator`, pools wrapper) is untouched. Kusama AH / Westend AH use `RewardCurveInflation` and are unaffected.

## Verification

- Unit tests (`tests/inflation.test.ts`): the recorded era-2229 mainnet value (69,215.6368394402 DOT) through the calculator → **2.93%** average staker return; missing-allocation → throws. Full suite green.
- End-to-end locally: patched project indexed live Asset Hub; the served result was `relaychain 3.971% / nomination-pool 3.622%` vs production's `8.79% / 7.94%` — ratio exactly 1/0.452, on-chain cross-check `69,215.6 × 365 ÷ 862.0M staked = 2.93%` average, ×max-validator factor = 3.97%.

## Deployment note

No re-indexing needed: the `StakingApy` row is overwritten each era, so the served value self-corrects at the first era rollover (≤24h) after deploying the updated polkadot-ah project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
